### PR TITLE
ONL-4315 - IE11 - Error when clicking on SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - 2020-03-13
+## [2.0.2] - 2020-03-13
 ### Fixes
 - Fix to mute error 'invalid operand to in' on IE11.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2020-03-13
+### Fixes
+- Fix to mute error 'invalid operand to in' on IE11.
+
 ## [2.0.1] - 2020-01-16
 ### Fixes
 - Fix to not modify the existing DEFAULT properties.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebury/huha",
   "description": "huha.js (Hyperactive Users Hint Analysis) is a JavaScript framework that measures the usability and user experience in an automated way, including the limitations of the model and the best practices.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": "github:Ebury/huha",
   "license": "MIT",
   "scripts": {

--- a/src/huha.js
+++ b/src/huha.js
@@ -438,7 +438,7 @@ class Huha {
     const events = ['click', 'focus', 'change'];
     events.forEach((eventName) => {
       document.querySelector('body').addEventListener(eventName, (evt) => {
-        if ('huhaTask' in evt.target.dataset) {
+        if (evt.target.dataset && 'huhaTask' in evt.target.dataset) {
           this.registerEvent(eventName, evt.target);
         }
       }, true);


### PR DESCRIPTION
Every time we click on an svg on IE11 we get an error. This is because the dataset property doesn't exist. This pr adds a check if dataset exists.